### PR TITLE
Fix issue causing elastic to consume too much memory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
       - efk_elasticsearch_data:/usr/share/elasticsearch/data
     networks:
       - efk
+    mem_limit: 1g
 
   kibana:
     image: "docker.elastic.co/kibana/kibana:7.2.0"

--- a/logging/filebeat.yml
+++ b/logging/filebeat.yml
@@ -22,8 +22,6 @@ output.elasticsearch:
         - equals:
             container.image.name: docker.elastic.co/beats/filebeat:7.2.0
         - equals:
-            container.image.name: docker.elastic.co/elasticsearch/elasticsearch:7.2.0
-        - equals:
             container.image.name: docker.elastic.co/kibana/kibana:7.2.0
     - index: "filebeat-minitwit-%{[agent.version]}-%{+yyyy.MM.dd}"
       when.equals:


### PR DESCRIPTION
# Description

Adds a memory limit to elastic and stops adding errors from itself causing a parse error.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


